### PR TITLE
Fix hex colours with transparency causing crashes.

### DIFF
--- a/src/main/kotlin/strongdmm/byond/dmm/ColorExtractor.kt
+++ b/src/main/kotlin/strongdmm/byond/dmm/ColorExtractor.kt
@@ -43,6 +43,8 @@ class ColorExtractor {
             var awtColor: AWTColor? = null
 
             if (colorValue.startsWith("#")) {
+                if (colorValue.length > 7)
+                    colorValue = colorValue.substring(0, 6)
                 awtColor = AWTColor.decode(colorValue)
             } else if (colorValue.isNotEmpty()) {
                 val hex = hexFromColorName(colorValue)


### PR DESCRIPTION
Fixes atoms where colour is set to a hex value with an alpha channel.
In short AWT color's decode does not support colours with alpha, so I am just cutting it out to prevent it from crashing.
This feels a bit hacky and it could probably be implemented correctly with a proper hex colour parser but I am a bit too lazy to do that.