### PR TITLE
Added a check to ignore line comments for dmm files.

### DIFF
--- a/src/main/kotlin/strongdmm/byond/dmm/parser/ByondParser.kt
+++ b/src/main/kotlin/strongdmm/byond/dmm/parser/ByondParser.kt
@@ -23,6 +23,9 @@ class ByondParser(
             if (line.isBlank()) {
                 posIdx += line.length + 1
                 continue
+            } else if (line.startsWith("//")) {
+                posIdx += line.length + 1
+                continue
             } else if (line.startsWith("(1,1,1)")) {
                 break
             }


### PR DESCRIPTION
I couldn't open my maps with StrongDMM due to my custom map-merger adding comments throughout the file, so I patched it so that it ignores comments in BYOND *.DMM files.

This PR is to feed this change back upstream.

Example *.dmm to test the change is attached, extension changed to txt to let me attach it!
[newmap.dmm.txt](https://github.com/SpaiR/StrongDMM/files/6612565/newmap.dmm.txt)

