### PR TITLE
Retrieve uniform indices at runtime using gl.GetUniformIndices

### DIFF
--- a/src/app/render/brush/brush.go
+++ b/src/app/render/brush/brush.go
@@ -18,7 +18,7 @@ var (
 	vbo uint32
 	ebo uint32
 
-	uniformLocationTransform int32
+	uniformLocationTransform  int32
 	uniformLocationHasTexture int32
 )
 

--- a/src/app/render/brush/brush.go
+++ b/src/app/render/brush/brush.go
@@ -70,12 +70,12 @@ func initShader(vertex, fragment string) {
 		log.Fatal("[brush] unable to create shader:", err)
 	}
 
-	indices := [2]uint32{}
-	uniforms, freeUniforms := gl.Strs("Transform\x00", "HasTexture\x00")
-	gl.GetUniformIndices(program, 2, uniforms, &indices[0])
-	freeUniforms()
-	uniformLocationTransform = int32(indices[0])
-	uniformLocationHasTexture = int32(indices[1])
+	uniformIndices := [2]uint32{}
+	uniformNames, freeUniformNames := gl.Strs("Transform\x00", "HasTexture\x00")
+	gl.GetUniformIndices(program, 2, uniformNames, &uniformIndices[0])
+	freeUniformNames()
+	uniformLocationTransform = int32(uniformIndices[0])
+	uniformLocationHasTexture = int32(uniformIndices[1])
 
 	log.Println("[brush] shader initialized")
 }

--- a/src/app/render/brush/brush.go
+++ b/src/app/render/brush/brush.go
@@ -17,6 +17,9 @@ var (
 	vao uint32
 	vbo uint32
 	ebo uint32
+
+	uniformLocationTransform int32
+	uniformLocationHasTexture int32
 )
 
 func TryInit() {
@@ -66,6 +69,14 @@ func initShader(vertex, fragment string) {
 	if program, err = platform.NewShaderProgram(vertex, fragment); err != nil {
 		log.Fatal("[brush] unable to create shader:", err)
 	}
+
+	indices := [2]uint32{}
+	uniforms, freeUniforms := gl.Strs("Transform\x00", "HasTexture\x00")
+	gl.GetUniformIndices(program, 2, uniforms, &indices[0])
+	freeUniforms()
+	uniformLocationTransform = int32(indices[0])
+	uniformLocationHasTexture = int32(indices[1])
+
 	log.Println("[brush] shader initialized")
 }
 

--- a/src/app/render/brush/shader.go
+++ b/src/app/render/brush/shader.go
@@ -1,10 +1,5 @@
 package brush
 
-const (
-	uniformLocationTransform  = 0
-	uniformLocationHasTexture = 1
-)
-
 func vertexShader() string {
 	return `
 #version 330 core


### PR DESCRIPTION
Fixes map not rendering in some cases.

Currently the code assumes uniforms will have specific locations, hardcoded as constants. This seems to not work consistently, especially across platforms, leading to failures when assigning the uniforms from Go code. As a result, the shader doesn't work correctly and the map contents fail to render, displaying only the blue background.

I wasn't sure about the best way to store the uniform indices, so at the moment they are vars in the `brush` package, which means no modification is necessary to code previously using the constants. That said, I'd be happy to move them to a more appropriate location as necessary.