### PR TITLE
Replace WindowHint with Show

### DIFF
--- a/src/app/window/window.go
+++ b/src/app/window/window.go
@@ -113,10 +113,9 @@ func (w *Window) setupGlfw() {
 		log.Fatal("[window] unable to initialize opengl:", err)
 	}
 
-	glfw.WindowHint(glfw.Visible, glfw.True)
-
 	window.Maximize()
 	window.SetSizeCallback(w.resizeCallback)
+	window.Show()
 
 	log.Println("[window] opengl initialized")
 


### PR DESCRIPTION
I believe `WindowHint` only applies to newly opened windows, it seems the correct func here is `Show`. Additionally, moved `Show` below `Maximize` - this makes the newly shown window start maximized, preventing any additional animations (from the desktop environment) from playing for the user.