### PR TITLE
Fix building on linux by adding missing(?) linker flags

### DIFF
--- a/src/third_party/sdmmparser/sdmmparser.go
+++ b/src/third_party/sdmmparser/sdmmparser.go
@@ -2,7 +2,8 @@ package sdmmparser
 
 /*
 #cgo CFLAGS: -I./lib
-#cgo LDFLAGS: -L./src/target/release -lsdmmparser -ldl -lm
+#cgo LDFLAGS: -L./src/target/release -lsdmmparser
+#cgo linux LDFLAGS: -ldl -lm
 #include <stdlib.h>
 #include "lib/sdmmparser.h"
 */

--- a/src/third_party/sdmmparser/sdmmparser.go
+++ b/src/third_party/sdmmparser/sdmmparser.go
@@ -2,7 +2,7 @@ package sdmmparser
 
 /*
 #cgo CFLAGS: -I./lib
-#cgo LDFLAGS: -L./src/target/release -lsdmmparser
+#cgo LDFLAGS: -L./src/target/release -lsdmmparser -ldl -lm
 #include <stdlib.h>
 #include "lib/sdmmparser.h"
 */


### PR DESCRIPTION
**NOTE:** I don't understand the reasoning behind this specific change, I don't know if this will work across platforms, there's likely a better way.
I'm opening this PR mostly for information, please at the very least check if this also compiles on windows.

The go build is failing for me when building sdmmparser, with linker errors. This links in additional libraries that seem to be necessary on linux.