### PR TITLE
Allow window interaction without focus

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements and Fixes
  * Added an option to change map size. To do that open a new "Settings" menu, available under the cog button in the top-right corner of the opened map pane;
+ * It's now possible to interact with the map window without first having to manually tab in. To support flow like: select instance -> change a var -> select another instance;
  * Minor GUI improvements.
 
 # v2.1.0.alpha

--- a/src/app/ui/cpwsarea/wsmap/pmap/tools.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/tools.go
@@ -46,7 +46,7 @@ func processTempToolMode(key, altKey int, modeName string) bool {
 		} else if lastActivePane != nil {
 			p = lastActivePane
 		}
-		if p != nil && !p.shortcuts.Visible() {
+		if p != nil && !(p.canvasControl.Active() || p.shortcuts.Visible()) {
 			return false
 		}
 	}


### PR DESCRIPTION
# Description

When the mouse is over the map window, it is allowed to do map-related hotkeys to work without first having to manually tab in.

resolve #125 

# Type of change

<!-- Please check options that are relevant. -->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
