### PR TITLE
Preferences for Quick Edit menu appearance 

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -4,8 +4,9 @@
  * Added an option to change map size. To do that open a new "Settings" menu, available under the cog button in the top-right corner of the opened map pane;
  * It's now possible to interact with the map window without first having to manually tab in. Specifically for: select instance -> change a var -> select another instance;
  * Added a preference to adjust the application framerate;
- * Minor GUI improvements;
- * Fixed attempting to pick/delete item pixel shifted off map does not work.
+ * Added preferences to control Quick Edit menu appearance: it can be shown in the tile context menu or on the map pane;
+ * Fixed attempting to pick/delete item pixel shifted off map does not work;
+ * Minor GUI improvements.
 
 # v2.1.0.alpha
 

--- a/src/app/preferences.go
+++ b/src/app/preferences.go
@@ -13,6 +13,8 @@ func (a *app) makePreferences() wsprefs.Prefs {
 	p.Add(wsprefs.GPInterface, a.makePreferenceInterfaceScale())
 	p.Add(wsprefs.GPInterface, a.makePreferenceInterfaceFps())
 	p.Add(wsprefs.GPControls, a.makePreferenceControlsAltScrollBehaviour())
+	p.Add(wsprefs.GPControls, a.makePreferenceControlsQuickEditContextMenu())
+	p.Add(wsprefs.GPControls, a.makePreferenceControlsQuickEditMapPane())
 	p.Add(wsprefs.GPEditor, a.makePreferenceEditorFormat())
 	p.Add(wsprefs.GPEditor, a.makePreferenceEditorSanitizeVariables())
 	p.Add(wsprefs.GPEditor, a.makePreferenceEditorNudgeMode())
@@ -76,6 +78,44 @@ func (a *app) makePreferenceControlsAltScrollBehaviour() wsprefs.BoolPref {
 		log.Println("[app] preferences changing, [controls#alternative_scroll_behaviour] to:", value)
 		cfg := a.preferencesConfig()
 		cfg.Prefs.Controls.AltScrollBehaviour = value
+		a.ConfigSaveV(cfg)
+	}
+
+	return p
+}
+
+func (a *app) makePreferenceControlsQuickEditContextMenu() wsprefs.BoolPref {
+	p := wsprefs.MakeBoolPref()
+	p.Name = "Quick Edit: Tile Context Menu"
+	p.Desc = "Controls whether Quick Edit should be shown in the tile context menu."
+	p.Label = "##quick_edit:tile_context_menu"
+
+	p.FGet = func() bool {
+		return a.preferencesConfig().Prefs.Controls.QuickEditContextMenu
+	}
+	p.FSet = func(value bool) {
+		log.Println("[app] preferences changing, [controls#quick_edit:tile_context_menu] to:", value)
+		cfg := a.preferencesConfig()
+		cfg.Prefs.Controls.QuickEditContextMenu = value
+		a.ConfigSaveV(cfg)
+	}
+
+	return p
+}
+
+func (a *app) makePreferenceControlsQuickEditMapPane() wsprefs.BoolPref {
+	p := wsprefs.MakeBoolPref()
+	p.Name = "Quick Edit: Map Pane"
+	p.Desc = "Controls whether Quick Edit should be shown on the map pane."
+	p.Label = "##quick_edit:map_pane"
+
+	p.FGet = func() bool {
+		return a.preferencesConfig().Prefs.Controls.QuickEditMapPane
+	}
+	p.FSet = func(value bool) {
+		log.Println("[app] preferences changing, [controls#quick_edit:map_pane] to:", value)
+		cfg := a.preferencesConfig()
+		cfg.Prefs.Controls.QuickEditMapPane = value
 		a.ConfigSaveV(cfg)
 	}
 

--- a/src/app/preferences_config.go
+++ b/src/app/preferences_config.go
@@ -49,6 +49,9 @@ func (a *app) loadPreferencesConfig() {
 				Scale: 100,
 				Fps:   60,
 			},
+			Controls: prefs.Controls{
+				QuickEditMapPane: true,
+			},
 			Editor: prefs.Editor{
 				SaveFormat: prefs.SaveFormatInitial,
 				NudgeMode:  prefs.SaveNudgeModePixel,

--- a/src/app/prefs/prefs.go
+++ b/src/app/prefs/prefs.go
@@ -12,7 +12,9 @@ type Interface struct {
 }
 
 type Controls struct {
-	AltScrollBehaviour bool
+	AltScrollBehaviour   bool
+	QuickEditContextMenu bool
+	QuickEditMapPane     bool
 }
 
 type Editor struct {

--- a/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
@@ -8,6 +8,7 @@ import (
 	"sdmm/app/render"
 	"sdmm/app/ui/cpwsarea/wsmap/pmap/canvas"
 	"sdmm/app/ui/cpwsarea/wsmap/pmap/editor"
+	"sdmm/app/ui/cpwsarea/wsmap/pmap/pquickedit"
 	"sdmm/app/ui/cpwsarea/wsmap/pmap/psettings"
 	"sdmm/app/ui/cpwsarea/wsmap/pmap/tilemenu"
 	"sdmm/app/ui/cpwsarea/wsmap/tools"
@@ -24,6 +25,7 @@ import (
 
 type App interface {
 	tilemenu.App
+	pquickedit.App
 
 	Prefs() prefs.Prefs
 
@@ -80,7 +82,7 @@ type PaneMap struct {
 
 	tileMenu *tilemenu.TileMenu
 
-	pQuickEdit *panelQuickEdit
+	pQuickEdit *pquickedit.Panel
 	pSettings  *psettings.Panel
 
 	showSettings bool
@@ -170,7 +172,7 @@ func New(app App, dmm *dmmap.Dmm) *PaneMap {
 
 	p.tileMenu = tilemenu.New(app, p.editor)
 
-	p.pQuickEdit = &panelQuickEdit{app: app, editor: p.editor}
+	p.pQuickEdit = pquickedit.New(app, p.editor)
 	p.pSettings = psettings.New(p.editor)
 
 	p.canvas = canvas.New()
@@ -221,7 +223,7 @@ func (p *PaneMap) Process() {
 		"quickEdit_"+p.dmm.Name,
 		pPosRightBottom,
 		p.active && p.app.HasSelectedInstance(),
-		p.pQuickEdit.process,
+		p.pQuickEdit.Process,
 	)
 	p.showPanel("canvasStat_"+p.dmm.Name, pPosBottom, p.showStatusPanel)
 }

--- a/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
@@ -222,7 +222,7 @@ func (p *PaneMap) Process() {
 	p.showPanelV(
 		"quickEdit_"+p.dmm.Name,
 		pPosRightBottom,
-		p.active && p.app.HasSelectedInstance(),
+		p.app.Prefs().Controls.QuickEditMapPane && p.active && p.app.HasSelectedInstance(),
 		p.pQuickEdit.Process,
 	)
 	p.showPanel("canvasStat_"+p.dmm.Name, pPosBottom, p.showStatusPanel)

--- a/src/app/ui/cpwsarea/wsmap/pmap/tilemenu/process.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/tilemenu/process.go
@@ -96,6 +96,12 @@ func (t *TileMenu) showInstanceControls(i *dmminstance.Instance, idx int) w.Layo
 
 	return w.Layout{
 		w.Custom(func() {
+			if t.app.Prefs().Controls.QuickEditContextMenu {
+				t.pQuickEdit.ProcessV(i)
+				imgui.Separator()
+			}
+		}),
+		w.Custom(func() {
 			if dm.IsPath(p.Path(), "/obj") || dm.IsPath(p.Path(), "/mob") {
 				w.Layout{
 					w.MenuItem(fmt.Sprint("Move to Top##move_to_top_", idx), t.doMoveToTop(i)).

--- a/src/app/ui/cpwsarea/wsmap/pmap/tilemenu/tilemenu.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/tilemenu/tilemenu.go
@@ -3,7 +3,10 @@ package tilemenu
 import (
 	"github.com/SpaiR/imgui-go"
 	"sdmm/app/command"
+	"sdmm/app/prefs"
+	"sdmm/app/ui/cpwsarea/wsmap/pmap/pquickedit"
 	"sdmm/app/ui/shortcut"
+	"sdmm/dmapi/dmenv"
 	"sdmm/dmapi/dmmap"
 	"sdmm/dmapi/dmmap/dmmdata/dmmprefab"
 	"sdmm/dmapi/dmmap/dmminstance"
@@ -25,6 +28,11 @@ type App interface {
 
 	HasSelectedPrefab() bool
 	SelectedPrefab() (*dmmprefab.Prefab, bool)
+
+	SelectedInstance() (*dmminstance.Instance, bool)
+
+	Prefs() prefs.Prefs
+	LoadedEnvironment() *dmenv.Dme
 }
 
 type editor interface {
@@ -38,6 +46,8 @@ type editor interface {
 	InstanceDelete(i *dmminstance.Instance)
 	InstanceReplace(i *dmminstance.Instance, prefab *dmmprefab.Prefab)
 	InstanceReset(i *dmminstance.Instance)
+
+	UpdateCanvasByCoords([]util.Point)
 }
 
 type TileMenu struct {
@@ -49,10 +59,12 @@ type TileMenu struct {
 	opened bool
 
 	tile *dmmap.Tile
+
+	pQuickEdit *pquickedit.Panel
 }
 
 func New(app App, editor editor) *TileMenu {
-	t := &TileMenu{app: app, editor: editor}
+	t := &TileMenu{app: app, editor: editor, pQuickEdit: pquickedit.New(app, editor)}
 	t.addShortcuts()
 	return t
 }


### PR DESCRIPTION
# Description

Added preferences to control Quick Edit menu appearance: it can be shown in the tile context menu or on the map pane.

resolves #117

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
