### PR TITLE
Added screenshot tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The editor provides a bunch of new features:
 * TGM support with built-in map merger (no need to use external scripts and pre-commit hooks);
 * Almost instant environment open;
 * Custom layers filter;
-* ~~Built-in screenshot tool;~~
+* Built-in screenshot tool;
 * Smooth zoom-in/zoom-out;
 * Robust "Search";
 * Improved shortcuts;

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.3.0.alpha
+
+### Screenshots!
+Tool to make maps screenshots is available. You can find it in the new settings menu for every map specifically.
+To create a screenshot select a directory where you want to create it and press an appropriate button.
+Resulted image will respect filtered types and multi-z rendering if enabled.
+
 # v2.2.0.alpha
 
 ### Improvements and Fixes

--- a/src/app/render/bucket.go
+++ b/src/app/render/bucket.go
@@ -27,7 +27,10 @@ func (r *Render) batchBucketUnits(viewBounds util.Bounds) {
 	}
 
 	r.batchLevel(r.Camera.Level, viewBounds, true) // Draw currently visible level.
-	r.overlay.FlushUnits()
+
+	if r.overlay != nil {
+		r.overlay.FlushUnits()
+	}
 }
 
 func (r *Render) batchLevel(level int, viewBounds util.Bounds, withUnitHighlight bool) {
@@ -49,7 +52,7 @@ func (r *Render) batchLevel(level int, viewBounds util.Bounds, withUnitHighlight
 					continue
 				}
 				// Process unit
-				if !r.unitProcessor.ProcessUnit(u) {
+				if r.unitProcessor != nil && !r.unitProcessor.ProcessUnit(u) {
 					continue
 				}
 
@@ -69,6 +72,9 @@ func (r *Render) batchLevel(level int, viewBounds util.Bounds, withUnitHighlight
 }
 
 func (r *Render) batchUnitHighlight(u unit.Unit) {
+	if r.overlay == nil {
+		return
+	}
 	if highlight := r.overlay.Units()[u.Instance().Id()]; highlight != nil {
 		r, g, b, a := highlight.Color().RGBA()
 		brush.RectTexturedV(

--- a/src/app/ui/cpwsarea/wsmap/pmap/canvas/canvas.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/canvas/canvas.go
@@ -9,6 +9,10 @@ import (
 	"sdmm/app/window"
 )
 
+type Color struct {
+	R, G, B, A float32
+}
+
 type Canvas struct {
 	render *render.Render
 
@@ -16,6 +20,8 @@ type Canvas struct {
 
 	frameBuffer uint32
 	texture     uint32
+
+	ClearColor Color
 }
 
 func (c *Canvas) Texture() uint32 {
@@ -24,6 +30,14 @@ func (c *Canvas) Texture() uint32 {
 
 func (c *Canvas) Render() *render.Render {
 	return c.render
+}
+
+func (c *Canvas) ReadPixels() []byte {
+	var pixels = make([]byte, int(c.width*c.height*4))
+	gl.BindTexture(gl.TEXTURE_2D, c.Texture())
+	gl.GetTexImage(gl.TEXTURE_2D, 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(pixels))
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+	return pixels
 }
 
 func (c *Canvas) Dispose() {
@@ -38,7 +52,7 @@ func (c *Canvas) Dispose() {
 }
 
 func New() *Canvas {
-	c := &Canvas{render: render.New()}
+	c := &Canvas{render: render.New(), ClearColor: Color{.25, .25, .5, 1}}
 	gl.GenFramebuffers(1, &c.frameBuffer)
 	return c
 }
@@ -47,7 +61,7 @@ func (c *Canvas) Process(size imgui.Vec2) {
 	c.updateCanvasTexture(size.X, size.Y)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, c.frameBuffer)
 	gl.Viewport(0, 0, int32(size.X), int32(size.Y))
-	gl.ClearColor(.25, .25, .5, 1)
+	gl.ClearColor(c.ClearColor.R, c.ClearColor.G, c.ClearColor.B, c.ClearColor.A)
 	gl.Clear(gl.COLOR_BUFFER_BIT)
 	c.render.Draw(size.X, size.Y)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)

--- a/src/app/ui/cpwsarea/wsmap/pmap/editor/editor.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/editor/editor.go
@@ -46,6 +46,10 @@ func (e *Editor) AreasZones() []AreaZone {
 	return e.areasZones
 }
 
+func (e *Editor) ActiveLevel() int {
+	return e.pMap.ActiveLevel()
+}
+
 type app interface {
 	DoSelectPrefab(prefab *dmmprefab.Prefab)
 	DoEditInstance(*dmminstance.Instance)

--- a/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/pmap.go
@@ -26,6 +26,7 @@ import (
 type App interface {
 	tilemenu.App
 	pquickedit.App
+	psettings.App
 
 	Prefs() prefs.Prefs
 
@@ -173,7 +174,7 @@ func New(app App, dmm *dmmap.Dmm) *PaneMap {
 	p.tileMenu = tilemenu.New(app, p.editor)
 
 	p.pQuickEdit = pquickedit.New(app, p.editor)
-	p.pSettings = psettings.New(p.editor)
+	p.pSettings = psettings.New(app, p.editor)
 
 	p.canvas = canvas.New()
 	p.canvasState = canvas.NewState(dmm.MaxX, dmm.MaxY, dmmap.WorldIconSize)

--- a/src/app/ui/cpwsarea/wsmap/pmap/psettings/config.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/psettings/config.go
@@ -1,0 +1,41 @@
+package psettings
+
+import (
+	"log"
+	"os/user"
+)
+
+const (
+	configName    = "psettings"
+	configVersion = 1
+)
+
+type psettingsConfig struct {
+	Version uint
+
+	ScreenshotDir string
+}
+
+func (psettingsConfig) Name() string {
+	return configName
+}
+
+func (psettingsConfig) TryMigrate(_ map[string]interface{}) (result map[string]interface{}, migrated bool) {
+	// do nothing. yet...
+	return nil, migrated
+}
+
+func loadConfig(app App) *psettingsConfig {
+	u, err := user.Current()
+	if err != nil {
+		log.Fatal("[psettings] unable to find user:", err)
+	}
+
+	cfg := &psettingsConfig{
+		Version: configVersion,
+
+		ScreenshotDir: u.HomeDir,
+	}
+	app.ConfigRegister(cfg)
+	return cfg
+}

--- a/src/app/ui/cpwsarea/wsmap/pmap/psettings/psettings.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/psettings/psettings.go
@@ -2,23 +2,48 @@ package psettings
 
 import (
 	"github.com/SpaiR/imgui-go"
-	"sdmm/app/ui/cpwsarea/wsmap/pmap/editor"
+	"sdmm/app/config"
 	"sdmm/app/window"
+	"sdmm/dmapi/dm"
+	"sdmm/dmapi/dmmap"
 )
 
-type Panel struct {
-	editor *editor.Editor
+type App interface {
+	PathsFilter() *dm.PathsFilter
 
-	sessionMapSize *sessionMapSize
+	ConfigRegister(config.Config)
+	ConfigSaveV(config.Config)
 }
 
-func New(editor *editor.Editor) *Panel {
-	return &Panel{editor: editor}
+type editor interface {
+	ActiveLevel() int
+
+	Dmm() *dmmap.Dmm
+	CommitMapSizeChange(oldMaxX, oldMaxY, oldMaxZ int)
+}
+
+type Panel struct {
+	app App
+
+	editor editor
+
+	sessionMapSize    *sessionMapSize
+	sessionScreenshot *sessionScreenshot
+}
+
+var cfg *psettingsConfig
+
+func New(app App, editor editor) *Panel {
+	if cfg == nil {
+		cfg = loadConfig(app)
+	}
+	return &Panel{app: app, editor: editor, sessionScreenshot: &sessionScreenshot{}}
 }
 
 func (p *Panel) Process() {
 	imgui.Dummy(imgui.Vec2{X: p.headerSize()})
 	p.showMapSize()
+	p.showScreenshot()
 }
 
 func (p *Panel) headerSize() float32 {

--- a/src/app/ui/cpwsarea/wsmap/pmap/psettings/screenshot.go
+++ b/src/app/ui/cpwsarea/wsmap/pmap/psettings/screenshot.go
@@ -1,0 +1,111 @@
+package psettings
+
+import (
+	"fmt"
+	"github.com/SpaiR/imgui-go"
+	"github.com/sqweek/dialog"
+	"image/png"
+	"log"
+	"os"
+	"sdmm/app/render/bucket/level/chunk/unit"
+	"sdmm/app/ui/cpwsarea/wsmap/pmap/canvas"
+	appdialog "sdmm/app/ui/dialog"
+	"sdmm/dmapi/dmmap"
+	"sdmm/imguiext/icon"
+	"sdmm/imguiext/style"
+	w "sdmm/imguiext/widget"
+	"sdmm/util"
+	"time"
+)
+
+type sessionScreenshot struct {
+	saving bool
+}
+
+func (p *Panel) showScreenshot() {
+	if imgui.CollapsingHeader("Screenshot") {
+		if imgui.Button(icon.FolderOpen) {
+			p.selectScreenshotDir()
+		}
+
+		imgui.SameLine()
+
+		imgui.SetNextItemWidth(-1)
+		imgui.InputText("##screenshot_dir", &cfg.ScreenshotDir)
+
+		if imgui.IsItemDeactivatedAfterEdit() {
+			p.app.ConfigSaveV(cfg)
+		}
+
+		var createBtnLabel string
+		if p.sessionScreenshot.saving {
+			createBtnLabel = "Creating" + []string{".", "..", "...", "...."}[int(imgui.Time()/.25)&3] + "###create"
+		} else {
+			createBtnLabel = "Create###create"
+		}
+
+		w.Layout{
+			w.Disabled(p.sessionScreenshot.saving,
+				w.Button(createBtnLabel, p.createScreenshot).
+					Size(imgui.Vec2{X: -1}).
+					Style(style.ButtonGreen{}),
+			),
+		}.Build()
+	}
+}
+
+func (p *Panel) createScreenshot() {
+	p.sessionScreenshot.saving = true
+
+	width, height := p.editor.Dmm().MaxX*dmmap.WorldIconSize, p.editor.Dmm().MaxY*dmmap.WorldIconSize
+
+	c := canvas.New()
+	c.ClearColor = canvas.Color{} // Empty clear color with no alpha
+	c.Render().Camera.Level = p.editor.ActiveLevel()
+	c.Render().SetUnitProcessor(p)
+	for level := 1; level <= p.editor.ActiveLevel(); level++ {
+		c.Render().UpdateBucket(p.editor.Dmm(), level) // Prepare for render all available levels
+	}
+	c.Process(imgui.Vec2{X: float32(width), Y: float32(height)})
+	c.Dispose()
+
+	var pixels = c.ReadPixels()
+
+	go func() {
+		if err := saveScreenshot(pixels, width, height); err != nil {
+			appdialog.Open(appdialog.TypeInformation{
+				Title:       "Error: Screenshot Creation",
+				Information: fmt.Sprint("Unable to create screenshot:", err),
+			})
+		}
+		p.sessionScreenshot.saving = false
+	}()
+}
+
+func (p *Panel) selectScreenshotDir() {
+	if dir, err := dialog.
+		Directory().
+		Title("Screenshot Directory").
+		SetStartDir(cfg.ScreenshotDir).
+		Browse(); err == nil {
+		log.Println("[psettings] screenshot directory selected:", dir)
+		cfg.ScreenshotDir = dir
+		p.app.ConfigSaveV(cfg)
+	}
+}
+
+func (p *Panel) ProcessUnit(u unit.Unit) bool {
+	return p.app.PathsFilter().IsVisiblePath(u.Instance().Prefab().Path())
+}
+
+func saveScreenshot(pixels []byte, w, h int) error {
+	if err := os.MkdirAll(cfg.ScreenshotDir, os.ModeDir); err != nil {
+		log.Println("[psettings] unable to create screenshot directory:", err)
+		return err
+	}
+
+	out, _ := os.Create(cfg.ScreenshotDir + "/" + time.Now().Format("2006.01.02-15.04.05") + ".png")
+	defer out.Close()
+
+	return png.Encode(out, util.PixelsToRGBA(pixels, w, h))
+}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -1,6 +1,10 @@
 package util
 
-import "github.com/sqweek/dialog"
+import (
+	"github.com/sqweek/dialog"
+	"image"
+	"image/color"
+)
 
 // Djb2 is hashing method implemented by spec: http://www.cse.yorku.ca/~oz/hash.html
 func Djb2(str string) uint64 {
@@ -23,4 +27,24 @@ func ShowErrorDialogV(title, msg string) {
 	b := dialog.MsgBuilder{Msg: msg}
 	b.Title(title)
 	b.Error()
+}
+
+// PixelsToRGBA creates an RGBA image from provided raw pixels.
+func PixelsToRGBA(pixels []byte, w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+
+	for x := 0; x < w; x++ {
+		for y := 0; y < h; y++ {
+			pos := 4 * ((h-1-y)*w + x)
+			r := pixels[pos] & 0xff
+			g := pixels[pos+1] & 0xff
+			b := pixels[pos+2] & 0xff
+			a := pixels[pos+3] & 0xff
+			if a != 0 {
+				img.Set(x, y, color.RGBA{R: r, G: g, B: b, A: a})
+			}
+		}
+	}
+
+	return img
 }


### PR DESCRIPTION
# Description

Tool to make maps screenshots is available. You can find it in the new settings menu for every map specifically.
To create a screenshot select a directory where you want to create it and press an appropriate button.
Resulted image will respect filtered types and multi-z rendering if enabled.

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
