### PR TITLE
Fix: keypad enter does not work

### DIFF
--- a/src/platform/glfw.go
+++ b/src/platform/glfw.go
@@ -64,6 +64,7 @@ func InitImGuiGLFW() {
 	io.KeyMap(imgui.KeyBackspace, int(glfw.KeyBackspace))
 	io.KeyMap(imgui.KeySpace, int(glfw.KeySpace))
 	io.KeyMap(imgui.KeyEnter, int(glfw.KeyEnter))
+	io.KeyMap(imgui.KeyKeyPadEnter, int(glfw.KeyKPEnter))
 	io.KeyMap(imgui.KeyEscape, int(glfw.KeyEscape))
 	io.KeyMap(imgui.KeyA, int(glfw.KeyA))
 	io.KeyMap(imgui.KeyC, int(glfw.KeyC))


### PR DESCRIPTION
# Description

Pressing <kbd>Enter</kbd> on the keypad does not behave (and not working at all) like normal one in input fields 😫

# Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
