### PR TITLE
rust-version is the *minimum required* version.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ compiled to a `staticlib`. You can find it by path: `src/third_party/sdmmparser/
 ### Pre-requests
 
 * [Go](https://go.dev/): version **1.18** or higher
-* [Rust](https://www.rust-lang.org/): version **1.60.0** or higher
+* [Rust](https://www.rust-lang.org/): version **1.56.0** or higher
 * (Optional) [Task](https://taskfile.dev): to run build scripts
 
 #### For Windows

--- a/src/third_party/sdmmparser/src/Cargo.toml
+++ b/src/third_party/sdmmparser/src/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sdmmparser"
 version = "2.0.0"
-rust-version = "1.61.0"
+rust-version = "1.56.0"
 
 [lib]
 name = "sdmmparser"


### PR DESCRIPTION
# Description
Setting this to the current version means you can only build with the very latest version. What it's meant for is to indicate what language features you're using/requiring.

I can verify that the correct value is >= 1.53, since you're using or-patterns. I can also verify that the correct value is <= 1.58.1, since that's what I have available, and it works fine.

1.56 seems like a conservative choice, since that's the 2021 edition, and also when the versioning was introduced. It's very likely that it builds correctly @1.56, since you've introduced almost no changes since then.

(I manually verified that the packages you've bumped versions on have much looser rust-version requirements.)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update