### PR TITLE
Changes the DM map format's name from DM to DMM

### DIFF
--- a/src/app/prefs/save.go
+++ b/src/app/prefs/save.go
@@ -3,11 +3,11 @@ package prefs
 const (
 	SaveFormatInitial = "Initial"
 	SaveFormatTGM     = "TGM"
-	SaveFormatDM      = "DM"
+	SaveFormatDM      = "DMM"
 
 	SaveFormatHelp = `Initial - the map will be saved in the format in which it was loaded
 TGM - a custom map format made by TG, helps to make map file more readable and reduce merge conflicts
-DM - a default map format used by the DM map editor
+DMM - a default map format used by the DM map editor
 `
 )
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The latter is correct. It was previously titled 'BYOND' in StrongDMM 1, which I suppose is also correct. However, the exact terminology and common parlance is to refer to it as DMM.

# Type of change

<!-- Please check options that are relevant. -->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
