### PR TITLE
Implement parent_type and tmp, static, and const vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ logs/
 .idea/
 
 # Binaries for programs and plugins
+/src/sdmm
 *.exe
 *.exe~
 *.dll

--- a/src/app/ui/cpvareditor/collect.go
+++ b/src/app/ui/cpvareditor/collect.go
@@ -9,9 +9,10 @@ import (
 )
 
 var unmodifiableVars = []string{
-	"type", "parent_type", "vars", "x", "y", "z", "contents", "filters",
+	"type", "parent_type", "vars", "x", "y", "z", "filters",
 	"loc", "maptext", "maptext_width", "maptext_height", "maptext_x", "maptext_y",
-	"overlays", "underlays", "verbs", "appearance", "vis_locs",
+	"overlays", "underlays", "verbs", "appearance", "vis_locs", "vis_contents",
+	"vis_flags", "bounds", "particles", "render_source", "render_target",
 }
 
 func collectVariablesNames(vars *dmvars.Variables) (variablesNames []string) {

--- a/src/app/ui/cpvareditor/config.go
+++ b/src/app/ui/cpvareditor/config.go
@@ -13,6 +13,7 @@ type vareditorConfig struct {
 	ShowModified bool
 	ShowByType   bool
 	ShowPins     bool
+	ShowTmp      bool
 
 	PinnedVarNames []string
 }

--- a/src/app/ui/cpvareditor/process.go
+++ b/src/app/ui/cpvareditor/process.go
@@ -246,12 +246,17 @@ func (v *VarEditor) showVarInput(varName string) {
 	varValue := v.currentVars().ValueV(varName, dmvars.NullValue)
 	initialValue := v.initialVarValue(varName)
 	isModified := initialValue != varValue
+	readonly := v.isReadOnly(varName)
 
 	var resetBtn *w.ButtonWidget
 	if isModified {
 		resetBtn = w.Button(icon.Undo+"##"+varName, func() {
 			v.setCurrentVariable(varName, initialValue)
 		}).Tooltip(initialValue).Style(style.ButtonFrame{})
+	}
+
+	if readonly {
+		imgui.BeginDisabled()
 	}
 
 	w.InputText(fmt.Sprint("##", v.prefab.Id(), varName), &varValue).
@@ -262,6 +267,10 @@ func (v *VarEditor) showVarInput(varName string) {
 			v.setCurrentVariable(varName, varValue)
 		}).
 		Build()
+
+	if readonly {
+		imgui.EndDisabled()
+	}
 }
 
 func (v *VarEditor) setCurrentVariable(varName, varValue string) {

--- a/src/app/ui/cpvareditor/process.go
+++ b/src/app/ui/cpvareditor/process.go
@@ -215,18 +215,11 @@ func (v *VarEditor) showVariable(varName string) {
 		imgui.SameLine()
 	}
 
-	readonly := v.isReadOnly(varName)
-	if readonly {
-		imgui.BeginDisabled()
-	}
-
+	imgui.BeginDisabledV(v.isReadOnly(varName))
 	v.showVarName(varName)
 	imgui.TableNextColumn()
 	v.showVarInput(varName)
-
-	if readonly {
-		imgui.EndDisabled()
-	}
+	imgui.EndDisabled()
 }
 
 func (v *VarEditor) showVarPin(varName string) {

--- a/src/app/ui/cpvareditor/process.go
+++ b/src/app/ui/cpvareditor/process.go
@@ -116,6 +116,10 @@ func (v *VarEditor) showControls() {
 				Selected(cfg.ShowPins).
 				Enabled(true).
 				Shortcut(platform.KeyModName(), "3"),
+			w.MenuItem("Show tmp, const, and static", v.doToggleShowTmp).
+				Selected(cfg.ShowTmp).
+				Enabled(true).
+				Shortcut(platform.KeyModName(), "4"),
 		}.Build()
 
 		imgui.EndPopup()
@@ -295,6 +299,10 @@ func (v *VarEditor) isFilteredVariable(varName string) bool {
 	}
 	// Show filtered by name only
 	if len(v.filterVarName) > 0 && !strings.Contains(varName, v.filterVarName) {
+		return true
+	}
+	// Hide tmp, const, and static
+	if !v.config().ShowTmp && v.app.LoadedEnvironment().Objects[v.prefab.Path()].Flags(varName).Any() {
 		return true
 	}
 	return false

--- a/src/app/ui/cpvareditor/process.go
+++ b/src/app/ui/cpvareditor/process.go
@@ -214,9 +214,19 @@ func (v *VarEditor) showVariable(varName string) {
 		v.showVarPin(varName)
 		imgui.SameLine()
 	}
+
+	readonly := v.isReadOnly(varName)
+	if readonly {
+		imgui.BeginDisabled()
+	}
+
 	v.showVarName(varName)
 	imgui.TableNextColumn()
 	v.showVarInput(varName)
+
+	if readonly {
+		imgui.EndDisabled()
+	}
 }
 
 func (v *VarEditor) showVarPin(varName string) {
@@ -250,17 +260,12 @@ func (v *VarEditor) showVarInput(varName string) {
 	varValue := v.currentVars().ValueV(varName, dmvars.NullValue)
 	initialValue := v.initialVarValue(varName)
 	isModified := initialValue != varValue
-	readonly := v.isReadOnly(varName)
 
 	var resetBtn *w.ButtonWidget
 	if isModified {
 		resetBtn = w.Button(icon.Undo+"##"+varName, func() {
 			v.setCurrentVariable(varName, initialValue)
 		}).Tooltip(initialValue).Style(style.ButtonFrame{})
-	}
-
-	if readonly {
-		imgui.BeginDisabled()
 	}
 
 	w.InputText(fmt.Sprint("##", v.prefab.Id(), varName), &varValue).
@@ -271,10 +276,6 @@ func (v *VarEditor) showVarInput(varName string) {
 			v.setCurrentVariable(varName, varValue)
 		}).
 		Build()
-
-	if readonly {
-		imgui.EndDisabled()
-	}
 }
 
 func (v *VarEditor) setCurrentVariable(varName, varValue string) {

--- a/src/app/ui/cpvareditor/shortcut.go
+++ b/src/app/ui/cpvareditor/shortcut.go
@@ -32,4 +32,12 @@ func (v *VarEditor) addShortcuts() {
 		SecondKeyAlt: glfw.KeyKP3,
 		Action:       v.doToggleShowPins,
 	})
+	v.shortcuts.Add(shortcut.Shortcut{
+		Name:         "cpvareditor#doToggleShowTmp",
+		FirstKey:     platform.KeyModLeft(),
+		FirstKeyAlt:  platform.KeyModRight(),
+		SecondKey:    glfw.Key4,
+		SecondKeyAlt: glfw.KeyKP4,
+		Action:       v.doToggleShowTmp,
+	})
 }

--- a/src/app/ui/cpvareditor/vareditor.go
+++ b/src/app/ui/cpvareditor/vareditor.go
@@ -202,6 +202,10 @@ func (v *VarEditor) initialVarValue(varName string) string {
 	return v.app.LoadedEnvironment().Objects[v.prefab.Path()].Vars.ValueV(varName, dmvars.NullValue)
 }
 
+func (v *VarEditor) isReadOnly(varName string) bool {
+	return v.app.LoadedEnvironment().Objects[v.prefab.Path()].Flags(varName).ReadOnly
+}
+
 func (v *VarEditor) isCurrentVarInitial(varName string) bool {
 	return v.currentVars().ValueV(varName, dmvars.NullValue) == v.initialVarValue(varName)
 }

--- a/src/app/ui/cpvareditor/vareditor.go
+++ b/src/app/ui/cpvareditor/vareditor.go
@@ -203,7 +203,7 @@ func (v *VarEditor) initialVarValue(varName string) string {
 }
 
 func (v *VarEditor) isReadOnly(varName string) bool {
-	return v.app.LoadedEnvironment().Objects[v.prefab.Path()].Flags(varName).ReadOnly
+	return v.app.LoadedEnvironment().Objects[v.prefab.Path()].Flags(varName).ReadOnly()
 }
 
 func (v *VarEditor) isCurrentVarInitial(varName string) bool {

--- a/src/app/ui/cpvareditor/vareditor.go
+++ b/src/app/ui/cpvareditor/vareditor.go
@@ -227,3 +227,9 @@ func (v *VarEditor) doToggleShowPins() {
 	cfg.ShowPins = !cfg.ShowPins
 	log.Println("[cpvareditor] toggle 'showPins':", cfg.ShowPins)
 }
+
+func (v *VarEditor) doToggleShowTmp() {
+	cfg := v.config()
+	cfg.ShowTmp = !cfg.ShowTmp
+	log.Println("[cpvareditor] toggle 'showTmp':", cfg.ShowTmp)
+}

--- a/src/dmapi/dmenv/dme.go
+++ b/src/dmapi/dmenv/dme.go
@@ -72,7 +72,8 @@ func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, parent *O
 		if treeVar.Decl {
 			var flags VarFlags
 			flags.Tmp = treeVar.IsTmp
-			flags.ReadOnly = treeVar.IsConst || treeVar.IsStatic
+			flags.Const = treeVar.IsConst
+			flags.Static = treeVar.IsStatic
 			varFlags[treeVar.Name] = flags
 		}
 	}

--- a/src/dmapi/dmenv/dme.go
+++ b/src/dmapi/dmenv/dme.go
@@ -53,6 +53,7 @@ func nameFromPath(path string, parentName string) string {
 
 func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, parent *Object, dme *Dme) {
 	variables := dmvars.MutableVariables{}
+	varFlags := make(map[string]VarFlags, len(root.Vars))
 	var name string
 
 	for _, treeVar := range root.Vars {
@@ -67,6 +68,13 @@ func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, parent *O
 		}
 
 		variables.Put(treeVar.Name, value)
+
+		if treeVar.Decl {
+			var flags VarFlags
+			flags.Tmp = treeVar.IsTmp
+			flags.ReadOnly = treeVar.IsConst || treeVar.IsStatic
+			varFlags[treeVar.Name] = flags
+		}
 	}
 
 	if _, ok := variables.Value("name"); !ok {
@@ -74,10 +82,11 @@ func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, parent *O
 	}
 
 	object := &Object{
-		env:    dme,
-		parent: parent,
-		Path:   root.Path,
-		Vars:   variables.ToImmutable(),
+		env:      dme,
+		parent:   parent,
+		Path:     root.Path,
+		Vars:     variables.ToImmutable(),
+		VarFlags: varFlags,
 	}
 
 	children := make([]string, 0, len(root.Children))

--- a/src/dmapi/dmenv/dme.go
+++ b/src/dmapi/dmenv/dme.go
@@ -30,16 +30,12 @@ func New(path string) (*Dme, error) {
 		return nil, fmt.Errorf("[dmenv] unable to create dme by path [%s]: %w", path, err)
 	}
 
-	traverseTree0(objectTreeType, "", &dme)
-
-	linkPathFamily(&dme, "/atom", "/datum")
-	linkPathFamily(&dme, "/atom/movable", "/atom")
-	linkPathFamily(&dme, "/area", "/atom")
-	linkPathFamily(&dme, "/turf", "/atom")
-	linkPathFamily(&dme, "/obj", "/atom/movable")
-	linkPathFamily(&dme, "/mob", "/atom/movable")
+	traverseTree0(objectTreeType, "", nil, &dme)
 
 	for _, object := range dme.Objects {
+		if parentType, ok := object.Vars.Value("parent_type"); ok {
+			object.parent = dme.Objects[parentType]
+		}
 		if object.parent != nil {
 			object.Vars.LinkParent(object.parent.Vars)
 		}
@@ -55,7 +51,7 @@ func nameFromPath(path string, parentName string) string {
 	return parentName
 }
 
-func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, dme *Dme) {
+func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, parent *Object, dme *Dme) {
 	variables := dmvars.MutableVariables{}
 	var name string
 
@@ -77,31 +73,21 @@ func traverseTree0(root *sdmmparser.ObjectTreeType, parentName string, dme *Dme)
 		variables.Put("name", nameFromPath(root.Path, parentName))
 	}
 
+	object := &Object{
+		env:    dme,
+		parent: parent,
+		Path:   root.Path,
+		Vars:   variables.ToImmutable(),
+	}
+
 	children := make([]string, 0, len(root.Children))
 	for _, child := range root.Children {
 		children = append(children, child.Path)
-		traverseTree0(&child, name, dme)
+		traverseTree0(&child, name, object, dme)
 	}
 
-	dme.Objects[root.Path] = &Object{
-		env:            dme,
-		Path:           root.Path,
-		Vars:           variables.ToImmutable(),
-		DirectChildren: children,
-	}
-}
-
-func linkPathFamily(dme *Dme, t string, parentType string) {
-	if object := dme.Objects[t]; object != nil {
-		linkFamily0(dme, object, parentType)
-	}
-}
-
-func linkFamily0(dme *Dme, object *Object, parentType string) {
-	object.parent = dme.Objects[parentType]
-	for _, child := range object.DirectChildren {
-		linkFamily0(dme, dme.Objects[child], object.Path)
-	}
+	object.DirectChildren = children
+	dme.Objects[root.Path] = object
 }
 
 func sanitizeVar(value string) string {

--- a/src/dmapi/dmenv/object.go
+++ b/src/dmapi/dmenv/object.go
@@ -9,6 +9,10 @@ type VarFlags struct {
 	ReadOnly bool
 }
 
+func (vf VarFlags) Any() bool {
+	return vf.Tmp || vf.ReadOnly
+}
+
 type Object struct {
 	env    *Dme
 	parent *Object

--- a/src/dmapi/dmenv/object.go
+++ b/src/dmapi/dmenv/object.go
@@ -4,15 +4,31 @@ import (
 	"sdmm/dmapi/dmvars"
 )
 
+type VarFlags struct {
+	Tmp      bool
+	ReadOnly bool
+}
+
 type Object struct {
 	env    *Dme
 	parent *Object
 
 	Vars           *dmvars.Variables
+	VarFlags       map[string]VarFlags
 	Path           string
 	DirectChildren []string
 }
 
 func (o *Object) Parent() *Object {
 	return o.parent
+}
+
+func (o *Object) Flags(varName string) VarFlags {
+	for o != nil {
+		if value, ok := o.VarFlags[varName]; ok {
+			return value
+		}
+		o = o.parent
+	}
+	return VarFlags{}
 }

--- a/src/dmapi/dmenv/object.go
+++ b/src/dmapi/dmenv/object.go
@@ -5,12 +5,17 @@ import (
 )
 
 type VarFlags struct {
-	Tmp      bool
-	ReadOnly bool
+	Tmp    bool
+	Const  bool
+	Static bool
 }
 
 func (vf VarFlags) Any() bool {
-	return vf.Tmp || vf.ReadOnly
+	return vf.Tmp || vf.Const || vf.Static
+}
+
+func (vf VarFlags) ReadOnly() bool {
+	return vf.Const || vf.Static
 }
 
 type Object struct {

--- a/src/third_party/sdmmparser/sdmmparser.go
+++ b/src/third_party/sdmmparser/sdmmparser.go
@@ -23,8 +23,12 @@ type ObjectTreeType struct {
 }
 
 type ObjectTreeVar struct {
-	Name  string
-	Value string
+	Name     string
+	Value    string
+	Decl     bool
+	IsTmp    bool `json:"is_tmp"`
+	IsConst  bool `json:"is_const"`
+	IsStatic bool `json:"is_static"`
 }
 
 func ParseEnvironment(environmentPath string) (*ObjectTreeType, error) {

--- a/src/third_party/sdmmparser/src/environment.rs
+++ b/src/third_party/sdmmparser/src/environment.rs
@@ -15,6 +15,10 @@ struct ObjectTreeType {
 struct ObjectTreeVar {
     name: String,
     value: String,
+    decl: bool,
+    is_tmp: bool,
+    is_const: bool,
+    is_static: bool,
 }
 
 pub fn parse_environment(path: String) -> String {
@@ -50,7 +54,7 @@ fn parse(env_path: &str) -> Option<String> {
 fn recurse_objtree(ty: TypeRef) -> ObjectTreeType {
     let mut entry = ObjectTreeType {
         path: ty.path.to_owned(),
-        vars: Vec::new(),
+        vars: Vec::with_capacity(ty.vars.len()),
         children: Vec::new(),
     };
 
@@ -63,6 +67,10 @@ fn recurse_objtree(ty: TypeRef) -> ObjectTreeType {
                 .as_ref()
                 .unwrap_or(Constant::null())
                 .to_string(),
+            decl: var.declaration.is_some(),
+            is_tmp: var.declaration.as_ref().map_or(false, |d| d.var_type.flags.is_tmp()),
+            is_const: var.declaration.as_ref().map_or(false, |d| d.var_type.flags.is_const()),
+            is_static: var.declaration.as_ref().map_or(false, |d| d.var_type.flags.is_static()),
         });
     }
 


### PR DESCRIPTION
# Description

- Implement `parent_type` support rather than hardcoding only the built-in parent types
- Forbid editing `const` and `static` variables, like DreamMaker does
- Hide `tmp`, `const`, and `static` variables by default, like DreamMaker does

# Type of change

- [x] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
