### PR TITLE
Fix deletion processing out of bounds tiles

### DIFF
--- a/internal/app/ui/cpwsarea/wsmap/tools/delete.go
+++ b/internal/app/ui/cpwsarea/wsmap/tools/delete.go
@@ -13,8 +13,8 @@ type ToolDelete struct {
 	deletedTiles map[util.Point]bool
 }
 
-func (ToolDelete) IgnoreBounds() bool {
-	return true
+func (t ToolDelete) IgnoreBounds() bool {
+	return !t.AltBehaviour()
 }
 
 func (ToolDelete) Name() string {


### PR DESCRIPTION
# Description

Fixes #164

Out of bounds is only allowed for the regular deletion tool which does not use the bound to determine tiles, however it is a problem with the alt function and causes an infinite recursion in findChunkBounds. This makes the out of bounds allowed condition determined by if the alt function is enabled, fixing the issue. Deletion continues to work as expected.

# Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
