### PR TITLE
Fix infinite scrolling when the canvas is exited during a scroll

### DIFF
--- a/internal/app/ui/cpwsarea/wsmap/pmap/canvas_camera.go
+++ b/internal/app/ui/cpwsarea/wsmap/pmap/canvas_camera.go
@@ -24,7 +24,7 @@ func (p *PaneMap) processCameraMove() {
 }
 
 func (p *PaneMap) processCameraZoom() {
-	if !p.canvasControl.Zoomed() {
+	if !p.canvasControl.Zoomed() || !p.canvasControl.Active() {
 		return
 	}
 


### PR DESCRIPTION
# Description

Fixes #147 

`processCameraZoom()` normally exits when there is no mouseScroll value (by checking `zoomed`, a var set by `processMouseScroll()`).

However, `processMouseScroll()` does not execute if the control is not `Active()`. This means if there is a mouseWheel value on the control and it is exited (no longer active) e.g. by entering the right-click menu, `zoomed` will not be set to false, meaning `processCameraZoom()` will continue to execute.

A simple fix for this is to check if the current control is active in `processCameraZoom()`.

# Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
