### PR TITLE
Fix list whitespace parsing

### DIFF
--- a/internal/dmapi/dmmap/dmmdata/parse.go
+++ b/internal/dmapi/dmmap/dmmdata/parse.go
@@ -44,6 +44,7 @@ func parse(file namedReader) (*DmmData, error) {
 		inCommentLine  bool
 		commentTrigger bool
 		inQuoteBlock   bool
+		inVarDataBlock bool
 		inKeyBlock     bool
 		inDataBlock    bool
 		inVarEditBlock bool
@@ -110,6 +111,9 @@ func parse(file namedReader) (*DmmData, error) {
 						currDatum = append(currDatum, c)
 					}
 				}
+				if inVarDataBlock { // retain any whitespace in the data block
+					currDatum = append(currDatum, c)
+				}
 				continue
 			}
 
@@ -154,6 +158,12 @@ func parse(file namedReader) (*DmmData, error) {
 								flushCurrVariable()
 							}
 							inVarEditBlock = false
+						} else if c == '(' && !inVarDataBlock { //list() parsing
+							inVarDataBlock = true;
+							currDatum = append(currDatum, c);
+						} else if c == ')' && inVarDataBlock {
+							inVarDataBlock = false;
+							currDatum = append(currDatum, c);
 						} else {
 							currDatum = append(currDatum, c)
 						}

--- a/internal/dmapi/dmmap/dmmdata/parse.go
+++ b/internal/dmapi/dmmap/dmmdata/parse.go
@@ -159,11 +159,11 @@ func parse(file namedReader) (*DmmData, error) {
 							}
 							inVarEditBlock = false
 						} else if c == '(' && !inVarDataBlock { //list() parsing
-							inVarDataBlock = true;
-							currDatum = append(currDatum, c);
+							inVarDataBlock = true
+							currDatum = append(currDatum, c)
 						} else if c == ')' && inVarDataBlock {
-							inVarDataBlock = false;
-							currDatum = append(currDatum, c);
+							inVarDataBlock = false
+							currDatum = append(currDatum, c)
 						} else {
 							currDatum = append(currDatum, c)
 						}

--- a/internal/dmapi/dmmap/dmmdata/parse_test.go
+++ b/internal/dmapi/dmmap/dmmdata/parse_test.go
@@ -215,7 +215,7 @@ no_ws=1;
 } 	, 	/obj/foo2 	, 	
  	/obj/foo1 	{no_ws=1} 	,
 	/obj/foo3{
-		liz = list("a" = 2, "c" = 3)
+		liz =   	list("a" 	= 2, "c" = 		3)  	
 	}) 	
 
 // Comment line that shouldn't flag TGM format
@@ -248,7 +248,7 @@ no_ws=1;
 
 	assert.Equal("/obj/foo3", prefabs[3].Path())
 	assert.ElementsMatch(prefabs[3].Vars().Iterate(), []string{"liz"})
-	assert.Equal("list(\"a\" = 2, \"c\" = 3)", prefabs[3].Vars().ValueV("liz", ""))
+	assert.Equal("list(\"a\" 	= 2, \"c\" = 		3)", prefabs[3].Vars().ValueV("liz", ""))
 }
 
 // Table-based test to check failure edge cases.

--- a/internal/dmapi/dmmap/dmmdata/parse_test.go
+++ b/internal/dmapi/dmmap/dmmdata/parse_test.go
@@ -213,7 +213,10 @@ no_ws=1;
   space  =  "\"	2 \\"  ;  
 	tab	=	3	;	
 } 	, 	/obj/foo2 	, 	
- 	/obj/foo1 	{no_ws=1} 	) 	
+ 	/obj/foo1 	{no_ws=1} 	,
+	/obj/foo3{
+		liz = list("a" = 2, "c" = 3)
+	}) 	
 
 // Comment line that shouldn't flag TGM format
 
@@ -228,7 +231,7 @@ no_ws=1;
 
 	require.Len(t, dmm.Dictionary, 1)
 	prefabs := dmm.Dictionary["aaa"]
-	require.Len(t, prefabs, 3)
+	require.Len(t, prefabs, 4)
 
 	assert.Equal("/obj/foo1", prefabs[0].Path())
 	assert.ElementsMatch(prefabs[0].Vars().Iterate(), []string{"no_ws", "space", "tab"})
@@ -242,6 +245,10 @@ no_ws=1;
 	assert.Equal("/obj/foo1", prefabs[2].Path())
 	assert.ElementsMatch(prefabs[2].Vars().Iterate(), []string{"no_ws"})
 	assert.Equal("1", prefabs[2].Vars().ValueV("no_ws", ""))
+
+	assert.Equal("/obj/foo3", prefabs[3].Path())
+	assert.ElementsMatch(prefabs[3].Vars().Iterate(), []string{"liz"})
+	assert.Equal("list(\"a\" = 2, \"c\" = 3)", prefabs[3].Vars().ValueV("liz", ""))
 }
 
 // Table-based test to check failure edge cases.


### PR DESCRIPTION
# Description

Fixes #187

StrongDMM ignores whitespace in var blocks, so that varedits like `x     = 2` will turn into `x = 2`. However, it does not account for non-string varedits with whitespace in them, including list(). I decided the best solution was to check if the whitespace was inside a block of `()` within a varedit, so `list()` would allow whitespace inside.

Admittedly this is a patch on solution since it won't actually *correct* strange whitespace within the block, but it does at least consistently keep whatever whitespace is there.

Tested by opening a map with an associative list varedit. The parser kept the whitespace as expected, and saved the map with the same whitespace.

A more robust associative list parsing system that properly parses keys and values should be made, but for now this is fine.

Tests passing

![image](https://github.com/SpaiR/StrongDMM/assets/10366817/a7e3ff07-4fa9-441c-baa5-ba1733f7811a)

Map with associative list containing whitespace:

![image](https://github.com/SpaiR/StrongDMM/assets/10366817/df9edd40-0b33-4098-969c-de0eaffe1438)

Map file after editing and saving, retaining its whitespace:

![image](https://github.com/SpaiR/StrongDMM/assets/10366817/52c64d90-9056-4ad7-990f-01391415fae7)

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
