### PR TITLE
Ensures whitespace inside text in list pops isn't duplicated

### DIFF
--- a/internal/dmapi/dmmap/dmmdata/parse.go
+++ b/internal/dmapi/dmmap/dmmdata/parse.go
@@ -111,7 +111,7 @@ func parse(file namedReader) (*DmmData, error) {
 						currDatum = append(currDatum, c)
 					}
 				}
-				if inVarDataBlock { // retain any whitespace in the data block
+				else if inVarDataBlock { // retain any whitespace in the data block
 					currDatum = append(currDatum, c)
 				}
 				continue

--- a/internal/dmapi/dmmap/dmmdata/parse_test.go
+++ b/internal/dmapi/dmmap/dmmdata/parse_test.go
@@ -215,7 +215,7 @@ no_ws=1;
 } 	, 	/obj/foo2 	, 	
  	/obj/foo1 	{no_ws=1} 	,
 	/obj/foo3{
-		liz =   	list("a" 	= 2, "c" = 		3)  	
+		liz =   	list("a" 	= 2, "c" = 		3, "long bit of text  " = "other	long bit 	of		text")  	
 	}) 	
 
 // Comment line that shouldn't flag TGM format
@@ -248,7 +248,7 @@ no_ws=1;
 
 	assert.Equal("/obj/foo3", prefabs[3].Path())
 	assert.ElementsMatch(prefabs[3].Vars().Iterate(), []string{"liz"})
-	assert.Equal("list(\"a\" 	= 2, \"c\" = 		3)", prefabs[3].Vars().ValueV("liz", ""))
+	assert.Equal("list(\"a\" 	= 2, \"c\" = 		3, \"long bit of text  \" = \"other	long bit 	of		text\")", prefabs[3].Vars().ValueV("liz", ""))
 }
 
 // Table-based test to check failure edge cases.


### PR DESCRIPTION
# Description

Testing was insufficent, and it caused us to miss an else if, which meant if both bools were flipped we'd duplicate text

Closes #209

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
