### PR TITLE
Autocorrect unenclosed strings and lists

### DIFF
--- a/internal/app/ui/cpvareditor/vareditor.go
+++ b/internal/app/ui/cpvareditor/vareditor.go
@@ -221,26 +221,26 @@ func (v *VarEditor) isCurrentVarInitial(varName string) bool {
 }
 
 func (v *VarEditor) checkForVarIssue(varName, varValue string) bool {
-	is_list, is_string := strings.HasPrefix(varValue, "list("), strings.HasPrefix(varValue, `"`)
-	variable_bad := false
-	enclosing_c := "This shouldnt be empty"
-	if is_string {
+	isList, isString := strings.HasPrefix(varValue, "list("), strings.HasPrefix(varValue, `"`)
+	variableBad := false
+	enclosingCharacter := "This shouldnt be empty"
+	if isString {
 		//we start and end with a quotation mark so we probably shouldnt break
-		enclosing_c = `"`
-		variable_bad = !strings.HasSuffix(varValue, `"`)
-	} else if is_list {
+		enclosingCharacter = `"`
+		variableBad = !strings.HasSuffix(varValue, enclosingCharacter)
+	} else if isList {
 		//if list is enclosed
-		enclosing_c = `)`
-		variable_bad = !strings.HasSuffix(varValue, enclosing_c)
+		enclosingCharacter = `)`
+		variableBad = !strings.HasSuffix(varValue, enclosingCharacter)
 	}
 
-	if variable_bad {
+	if variableBad {
 		dialog.Open(dialog.TypeInformation{
 			Title:       "Variable Error!",
-			Information: "Variable " + varName + ", of value\n" + varValue + "\nis not enclosed with a " + enclosing_c + " !",
+			Information: "Variable " + varName + ", of value\n" + varValue + "\nis not enclosed with a " + enclosingCharacter + " !",
 		})
 	}
-	return variable_bad
+	return variableBad
 }
 
 func (v *VarEditor) doToggleShowModified() {

--- a/internal/app/ui/cpvareditor/vareditor.go
+++ b/internal/app/ui/cpvareditor/vareditor.go
@@ -135,7 +135,7 @@ func (v *VarEditor) setInstanceVariable(varName, varValue string) {
 	if len(varValue) == 0 {
 		varValue = dmvars.NullValue
 	}
-	
+
 	if v.checkForVarIssue(varName, varValue) {
 		return
 	}
@@ -173,7 +173,7 @@ func (v *VarEditor) setPrefabVariable(varName, varValue string) {
 	if len(varValue) == 0 {
 		varValue = dmvars.NullValue
 	}
-	
+
 	if v.checkForVarIssue(varName, varValue) {
 		return
 	}
@@ -221,9 +221,9 @@ func (v *VarEditor) isCurrentVarInitial(varName string) bool {
 }
 
 func (v *VarEditor) checkForVarIssue(varName, varValue string) bool {
-	is_list, is_string := strings.HasPrefix(varValue, "list(") , strings.HasPrefix(varValue, `"`)
+	is_list, is_string := strings.HasPrefix(varValue, "list("), strings.HasPrefix(varValue, `"`)
 	variable_bad := false
-	enclosing_c := "This shouldnt be empty" 
+	enclosing_c := "This shouldnt be empty"
 	if is_string {
 		//we start and end with a quotation mark so we probably shouldnt break
 		enclosing_c = `"`
@@ -233,7 +233,7 @@ func (v *VarEditor) checkForVarIssue(varName, varValue string) bool {
 		enclosing_c = `)`
 		variable_bad = !strings.HasSuffix(varValue, enclosing_c)
 	}
-	
+
 	if variable_bad {
 		dialog.Open(dialog.TypeInformation{
 			Title:       "Variable Error!",


### PR DESCRIPTION
# Description

If the user tries to change a variable to stuff like
list(hi
"im a string
it automatically corrects to
list(hi)
"im a string"
# Type of change

<!-- Please check options that are relevant. -->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
