### PR TITLE
Adds border-fill to the border fill tool

### DIFF
--- a/internal/app/ui/cpwsarea/wsmap/pmap/panel_tools.go
+++ b/internal/app/ui/cpwsarea/wsmap/pmap/panel_tools.go
@@ -50,6 +50,7 @@ var (
 				w.Separator(),
 				w.Text("Fill the area with the selected object"),
 				w.Line(w.TextFrame("Hold Alt"), w.Text("Fill the selected area with the selected object with replace")),
+				w.Line(w.TextFrame("Hold Ctrl"), w.Text("Fill the area with the selected, borders only")),
 			},
 		},
 		tools.TNGrab: {

--- a/internal/app/ui/cpwsarea/wsmap/pmap/panel_tools.go
+++ b/internal/app/ui/cpwsarea/wsmap/pmap/panel_tools.go
@@ -50,7 +50,7 @@ var (
 				w.Separator(),
 				w.Text("Fill the area with the selected object"),
 				w.Line(w.TextFrame("Hold Alt"), w.Text("Fill the selected area with the selected object with replace")),
-				w.Line(w.TextFrame("Hold Ctrl"), w.Text("Fill the area with the selected, borders only")),
+				w.Line(w.TextFrame("Hold Ctrl"), w.Text("Fill the area with the selected object, borders only")),
 			},
 		},
 		tools.TNGrab: {

--- a/internal/app/ui/cpwsarea/wsmap/tools/fill.go
+++ b/internal/app/ui/cpwsarea/wsmap/tools/fill.go
@@ -70,7 +70,6 @@ func (t *ToolFill) onStop(util.Point) {
 		return
 	}
 
-	bordersOnly := imguiext.IsCtrlDown()
 	// Fill the area.
 	if prefab, ok := ed.SelectedPrefab(); ok {
 		fillTile := func(x, y int) {
@@ -78,7 +77,7 @@ func (t *ToolFill) onStop(util.Point) {
 			tile := ed.Dmm().GetTile(coord)
 			t.basicPrefabAdd(tile, prefab)
 		}
-		if bordersOnly {
+		if imguiext.IsCtrlDown() {
 			rows := []float32{t.fillArea.Y1, t.fillArea.Y2}
 			columns := []float32{t.fillArea.X1, t.fillArea.X2}
 			for x := t.fillArea.X1; x <= t.fillArea.X2; x++ {

--- a/internal/app/ui/cpwsarea/wsmap/tools/fill.go
+++ b/internal/app/ui/cpwsarea/wsmap/tools/fill.go
@@ -5,6 +5,7 @@ import (
 
 	"sdmm/internal/app/ui/cpwsarea/wsmap/pmap/overlay"
 
+	"sdmm/internal/imguiext"
 	"sdmm/internal/util"
 )
 
@@ -69,13 +70,32 @@ func (t *ToolFill) onStop(util.Point) {
 		return
 	}
 
+	bordersOnly := imguiext.IsCtrlDown()
 	// Fill the area.
 	if prefab, ok := ed.SelectedPrefab(); ok {
-		for x := t.fillArea.X1; x <= t.fillArea.X2; x++ {
+		fillTile := func(x, y int) {
+			coord := util.Point{X: x, Y: y, Z: t.start.Z}
+			tile := ed.Dmm().GetTile(coord)
+			t.basicPrefabAdd(tile, prefab)
+		}
+		if bordersOnly {
+			rows := []float32{t.fillArea.Y1, t.fillArea.Y2}
+			columns := []float32{t.fillArea.X1, t.fillArea.X2}
+			for x := t.fillArea.X1; x <= t.fillArea.X2; x++ {
+				for _, coordinate := range rows {
+					fillTile(int(x), int(coordinate))
+				}
+			}
 			for y := t.fillArea.Y1; y <= t.fillArea.Y2; y++ {
-				coord := util.Point{X: int(x), Y: int(y), Z: t.start.Z}
-				tile := ed.Dmm().GetTile(coord)
-				t.basicPrefabAdd(tile, prefab)
+				for _, coordinate := range columns {
+					fillTile(int(coordinate), int(y))
+				}
+			}
+		} else {
+			for x := t.fillArea.X1; x <= t.fillArea.X2; x++ {
+				for y := t.fillArea.Y1; y <= t.fillArea.Y2; y++ {
+					fillTile(int(x), int(y))
+				}
 			}
 		}
 


### PR DESCRIPTION
# Description
holding ctrl while using the fill tool now performs a borders-only fill


https://github.com/SpaiR/StrongDMM/assets/70376633/5af166ed-ce82-4acf-a4e5-e10a17ed71f7



# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
