### PR TITLE
Find on Map searches by path

### DIFF
--- a/internal/app/ui/cpenvironment/environment.go
+++ b/internal/app/ui/cpenvironment/environment.go
@@ -18,7 +18,7 @@ type App interface {
 	LoadedEnvironment() *dmenv.Dme
 	DoSelectPrefabByPath(string)
 	DoEditPrefabByPath(string)
-	DoSearchPrefab(prefabId uint64)
+	DoSearchPrefabByPath(path string)
 	HasActiveMap() bool
 	ShowLayout(name string, focus bool)
 	PathsFilter() *dm.PathsFilter

--- a/internal/app/ui/cpenvironment/menu.go
+++ b/internal/app/ui/cpenvironment/menu.go
@@ -28,6 +28,6 @@ func (e *Environment) doFindOnMap(n *treeNode) func() {
 		prefab := dmmap.PrefabStorage.Initial(n.orig.Path)
 		log.Print("do find object on map:", prefab.Path())
 		e.app.ShowLayout(lnode.NameSearch, true)
-		e.app.DoSearchPrefab(prefab.Id())
+		e.app.DoSearchPrefabByPath(prefab.Path())
 	}
 }


### PR DESCRIPTION
# Description
find on map searches by path instead of prefab id
this is good because in the case of ss13 directionals it wouldnt find them if you searched for the parent prefab

https://github.com/SpaiR/StrongDMM/assets/70376633/865b6dfa-838d-46bc-a3f0-3999d8b0f74c



# Type of change

<!-- Please check options that are relevant. -->

- [x] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
