### PR TITLE
Fix wide missed icon placeholder

### DIFF
--- a/internal/dmapi/dmicon/editor.go
+++ b/internal/dmapi/dmicon/editor.go
@@ -15,7 +15,7 @@ func initEditorSprites() {
 	img := atlas.RGBA()
 
 	dmi := &Dmi{
-		IconWidth:     64,
+		IconWidth:     32,
 		IconHeight:    32,
 		TextureWidth:  atlas.Width,
 		TextureHeight: atlas.Height,


### PR DESCRIPTION
# Description
Fixes #242. The AMD fix PR contained an error. The icons are still 32x32, there's just a second column.

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
