### PR TITLE
correct the path of sdmmparser/src in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ With Task installed:
 #### Manually
 
 1. First, build the **sdmmparser** library.\
-   Navigate to `internal/third_party/sdmmparser/src` and run `cargo build --release`.\
+   Navigate to `third_party/sdmmparser/src` and run `cargo build --release`.\
    This step is needed only once unless **sdmmparser** is modified.
 2. In the root directory:
     * `go build .`: Builds the editor (executable named `sdmm.exe`/`sdmm` in the root).


### PR DESCRIPTION
# Description

`internal/third_party/sdmmparser/src` does not exist but `third_party/sdmmparser/src` does

# Type of change

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
