### PR TITLE
Fix dir being ignored in preview for nodes

### DIFF
--- a/internal/app/ui/cpenvironment/node.go
+++ b/internal/app/ui/cpenvironment/node.go
@@ -15,6 +15,7 @@ type treeNode struct {
 	orig   *dmenv.Object
 	sprite *dmicon.Sprite
 	color  imgui.Vec4
+	dir    int
 }
 
 func (e *Environment) newTreeNode(object *dmenv.Object) (*treeNode, bool) {
@@ -31,6 +32,7 @@ func (e *Environment) newTreeNode(object *dmenv.Object) (*treeNode, bool) {
 	icon, _ := object.Vars.Text("icon")
 	iconState, _ := object.Vars.Text("icon_state")
 	color := imgui.Vec4{X: 1, Y: 1, Z: 1, W: 1}
+	dir, _ := object.Vars.Int("dir")
 
 	if col, _ := object.Vars.Text("color"); col != "" {
 		r, g, b, _ := util.ParseColor(col).RGBA()
@@ -40,8 +42,9 @@ func (e *Environment) newTreeNode(object *dmenv.Object) (*treeNode, bool) {
 	node := &treeNode{
 		name:   object.Path[strings.LastIndex(object.Path, "/")+1:],
 		orig:   object,
-		sprite: dmicon.Cache.GetSpriteOrPlaceholder(icon, iconState),
+		sprite: dmicon.Cache.GetSpriteOrPlaceholderV(icon, iconState, dir),
 		color:  color,
+		dir:    dir,
 	}
 
 	e.treeNodes[object.Path] = node


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR makes it so tree nodes will respect the atom's `dir` var when rendering a preview.

Instead of: 
![image](https://github.com/user-attachments/assets/57e5905f-8ee5-404a-bd45-9b60e65d1cc6)

You will now see:
![image](https://github.com/user-attachments/assets/54ae4b46-a720-4f29-8337-b7d7dc2027bb)

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
