### PR TITLE
makes the border mode on the fill tool not double place on corners

### DIFF
--- a/internal/app/ui/cpwsarea/wsmap/tools/fill.go
+++ b/internal/app/ui/cpwsarea/wsmap/tools/fill.go
@@ -78,16 +78,12 @@ func (t *ToolFill) onStop(util.Point) {
 			t.basicPrefabAdd(tile, prefab)
 		}
 		if imguiext.IsCtrlDown() {
-			rows := []float32{t.fillArea.Y1, t.fillArea.Y2}
-			columns := []float32{t.fillArea.X1, t.fillArea.X2}
 			for x := t.fillArea.X1; x <= t.fillArea.X2; x++ {
-				for _, coordinate := range rows {
-					fillTile(int(x), int(coordinate))
-				}
-			}
-			for y := t.fillArea.Y1; y <= t.fillArea.Y2; y++ {
-				for _, coordinate := range columns {
-					fillTile(int(coordinate), int(y))
+				for y := t.fillArea.Y1; y <= t.fillArea.Y2; y++ {
+					if y > t.fillArea.Y1 && y < t.fillArea.Y2 && x > t.fillArea.X1 && x < t.fillArea.X2 {
+						continue
+					}
+					fillTile(int(x), int(y))
 				}
 			}
 		} else {


### PR DESCRIPTION
# Description

makes the border mode on the fill tool not double place on corners
fixes #327

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
