### PR TITLE
use UserConfigDir to store configuration

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -172,15 +172,15 @@ func (a *app) dispose() {
 func getOrCreateInternalDir() string {
 	var internalDir string
 
-	userHomeDir, err := os.UserHomeDir()
+	UserConfigDir, err := os.UserConfigDir()
 	if err != nil {
-		panic("unable to find user home dir")
+		panic("unable to find user config dir")
 	}
 
 	if runtime.GOOS == "windows" {
-		internalDir = userHomeDir + "/AppData/Roaming/StrongDMM"
+		internalDir = UserConfigDir + "/Roaming/StrongDMM"
 	} else {
-		internalDir = userHomeDir + "/.strongdmm"
+		internalDir = UserConfigDir + "/StrongDMM"
 	}
 	_ = os.MkdirAll(internalDir, os.ModePerm)
 


### PR DESCRIPTION
# Description
I found that Go language has useful UserConfigDir function which helps detecting config directories on different operating systems. It also fixes config placement on Linux distributions: instead cluttering home directory, it will put program config in $HOME/.config/StrongDMM.

This change IS breaking, because adjusts config directory path on all platforms.
On Windows everything should be unchanged, but I didn't test on it yet (only on Linux).

# Type of change
- [X] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
