### PR TITLE
just use `windows-latest` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
   lint-source-code:
     name: Lint Source Code
@@ -29,11 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2019, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             rust-target: 1.82-x86_64-unknown-linux-gnu
-          - os: windows-2019
+          - os: windows-latest
             rust-target: 1.82-x86_64-pc-windows-gnu
           - os: macos-latest
             rust-target: 1.82-x86_64-apple-darwin
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-    
+
       - name: Setup Task
         uses: arduino/setup-task@v2
         with:


### PR DESCRIPTION
# Description

this just makes the windows CI use `windows-latest`, as github actions no longer supports `windows-2019` - and we use `ubuntu-latest` and `macos-latest` anyways, so I'm not entirely sure why we can't do that for windows too, especially since abi compatibility is much less of an issue on windows afaik.

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
