### PR TITLE
Fix hanging on restart after update

### DIFF
--- a/internal/app/window/restart.go
+++ b/internal/app/window/restart.go
@@ -38,7 +38,7 @@ func restartSelf() error {
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = os.Stdin
 		cmd.Env = env
-		err := cmd.Run()
+		err := cmd.Start()
 		if err == nil {
 			os.Exit(0)
 		}


### PR DESCRIPTION
# Description

Fixes #140
`Command.Run` waits for the child process to finish before continuing execution, this blocks `os.Exit` from running, `Command.Start` doesn't wait.

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
