### PR TITLE
Fix go-to-definition for VSC to open the workspace root

### DIFF
--- a/internal/app/ui/cpenvironment/menu.go
+++ b/internal/app/ui/cpenvironment/menu.go
@@ -60,8 +60,9 @@ func (e *Environment) doGoToDefinition(n *treeNode) func() {
 
 		switch editorPrefs.CodeEditor {
 		case prefs.CodeEditorVSC:
+			root := filepath.FromSlash(e.app.LoadedEnvironment().RootDir)
 			argument := path + ":" + fmt.Sprint(location.Line) + ":" + fmt.Sprint(location.Column)
-			command = exec.Command(prefs.CodeEditorVSCActual, "-g", argument)
+			command = exec.Command(prefs.CodeEditorVSCActual, root, "-g", argument)
 		case prefs.CodeEditorDM:
 			// No line/col support until https://www.byond.com/forum/post/2970625
 			command = exec.Command(prefs.CodeEditorDMActual, path)


### PR DESCRIPTION
# Description

Applies the patch suggested in #351, which I tested.

# Type of change

- [x] Minor changes or tweaks (quality of life stuff)
