### PR TITLE
Start camera at map's center instead of bottom-left

### DIFF
--- a/internal/app/ui/cpwsarea/wsmap/pmap/pmap.go
+++ b/internal/app/ui/cpwsarea/wsmap/pmap/pmap.go
@@ -101,6 +101,7 @@ type PaneMap struct {
 	pos, size imgui.Vec2
 	focused   bool
 	active    bool
+	centered  bool
 
 	panelTopSize         imgui.Vec2
 	panelRightTopSize    imgui.Vec2
@@ -206,6 +207,12 @@ func (p *PaneMap) Process() {
 	p.pos = imgui.WindowPos().Plus(imgui.WindowContentRegionMin())
 	p.size = imgui.WindowSize()
 	p.focused = imgui.IsWindowFocusedV(imgui.FocusedFlagsRootAndChildWindows)
+
+	if !p.centered {
+		// On first load, set the camera to the center of the map, taking UI size into account.
+		p.canvas.Render().Camera.Translate(float32((int(p.size.X)-p.dmm.MaxX*dmmap.WorldIconSize)/2), float32((int(p.size.Y)-p.dmm.MaxY*dmmap.WorldIconSize)/2))
+		p.centered = true
+	}
 
 	p.canvas.Render().SetActiveLevel(p.dmm, p.activeLevel)
 


### PR DESCRIPTION
# Description

Automatically scrolls to the center of newly opened maps.

Currently, loading large maps leaves me looking at the empty southwest corner and I always have to scroll a fair ways northeast first. Small maps are the opposite, I always have to scroll southwest to get it out of the corner. Instead, centering all maps means I either don't need to scroll or can easily orient myself.

# Type of change

- [x] Minor changes or tweaks (quality of life stuff)
