### PR TITLE
Show var modifications under prefab name

### DIFF
--- a/internal/app/ui/cpprefabs/process.go
+++ b/internal/app/ui/cpprefabs/process.go
@@ -2,7 +2,9 @@ package cpprefabs
 
 import (
 	"fmt"
+	"strings"
 
+	"sdmm/internal/dmapi/dmvars"
 	w "sdmm/internal/imguiext/widget"
 
 	"github.com/SpaiR/imgui-go"
@@ -56,11 +58,34 @@ func (p *Prefabs) Process(int32) {
 		imgui.SameLine()
 
 		imgui.BeginGroup()
+		imgui.PushStyleVarVec2(imgui.StyleVarItemSpacing, imgui.Vec2{X: 0, Y: 0})
 		imgui.Text(node.name)
+		imgui.TextColored(imgui.Vec4{X: 0.6, Y: 0.6, Z: 0.6, W: 1}, describeVars(node.orig.Vars()))
+		imgui.PopStyleVar()
 		imgui.EndGroup()
 
 		imgui.EndGroup()
 
 		node.visHeight = imgui.ItemRectMax().Y - imgui.ItemRectMin().Y
 	}
+}
+
+func describeVars(variables *dmvars.Variables) string {
+	// "name" is already plainly visible and can be skipped.
+	// "icon", "icon_state", "dir", and "color" do affect the sprite, but are
+	// included in the list in case the effect is not obvious.
+	b := strings.Builder{}
+	for _, key := range variables.Iterate() {
+		if key == "name" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(key)
+		b.WriteString(" = ")
+		value, _ := variables.Value(key)
+		b.WriteString(value)
+	}
+	return b.String()
 }


### PR DESCRIPTION
# Description

Closes #374. I tried my hand at this feature request; I think it came out okay.

Gallery:

<img width="294" height="140" alt="image" src="https://github.com/user-attachments/assets/2e6aee44-ee6f-4ecb-b19a-1536d69f26a8" />
<img width="294" height="141" alt="image" src="https://github.com/user-attachments/assets/0cae1834-8667-4ed4-b32d-445166227f59" />
<img width="294" height="213" alt="image" src="https://github.com/user-attachments/assets/f4522dab-5531-4700-9c71-28f26d7a00b9" />
<img width="294" height="176" alt="image" src="https://github.com/user-attachments/assets/097d67f8-1326-4e02-8407-e41d1baa666f" />
<img width="294" height="345" alt="image" src="https://github.com/user-attachments/assets/ec724efe-28d8-4547-acda-16dda091a9b9" />
<img width="294" height="250" alt="image" src="https://github.com/user-attachments/assets/579ed54f-059b-42ed-9392-8e3b72fa06ae" />

# Type of change

- [x] New feature (non-breaking change which adds functionality)
