### PR TITLE
Synchronize unmodifiable vars list with DM

### DIFF
--- a/internal/app/ui/cpvareditor/collect.go
+++ b/internal/app/ui/cpvareditor/collect.go
@@ -9,10 +9,12 @@ import (
 )
 
 var unmodifiableVars = []string{
-	"type", "parent_type", "vars", "x", "y", "z", "filters",
-	"loc", "maptext", "maptext_width", "maptext_height", "maptext_x", "maptext_y",
-	"overlays", "underlays", "verbs", "appearance", "vis_locs", "vis_contents",
-	"vis_flags", "bounds", "particles", "render_source", "render_target",
+	"type", "parent_type", "vars",
+	"x", "y", "z",
+	"loc", "locs", "pixloc",
+	"maptext", "maptext_width", "maptext_height", "maptext_x", "maptext_y",
+	"verbs", "appearance", "vis_locs", "vis_contents",
+	"bounds", "particles", "render_source", "render_target",
 }
 
 func collectVariablesNames(vars *dmvars.Variables) (variablesNames []string) {


### PR DESCRIPTION
# Description

I recently checked DM to confirm what vars it allows. It looks like "filters", "underlays", "overlays", and "vis_flags" are now editor-worthy, and "locs" and "pixloc" are not.

Previously: #163.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
