### PR TITLE
Fix rendering panic on Z resize

### DIFF
--- a/internal/app/render/bucket.go
+++ b/internal/app/render/bucket.go
@@ -35,6 +35,9 @@ func (r *Render) batchBucketUnits(viewBounds util.Bounds) {
 
 func (r *Render) batchLevel(level int, viewBounds util.Bounds, withUnitHighlight bool) {
 	visibleLevel := r.bucket.Level(level)
+	if visibleLevel == nil {
+		return
+	}
 
 	// Iterate through every layer to render.
 	for _, layer := range visibleLevel.Layers {


### PR DESCRIPTION
# Description

When the quantity of Z levels are changed, and you aren't looking at the first Z, `visibleLevel := r.bucket.Level(level)` will be nil because the length of bucket `levels` is 1 instead of say 2. Let me know if there's a better way to flush out rendering work on a resize, but this is a more general solution that should be more reliable.

Fixes https://discord.com/channels/484170914754330625/485190298050363393/1476400437623259216 (Coderbus)
<img width="1478" height="880" alt="image" src="https://github.com/user-attachments/assets/ec619e54-2d15-482d-a1fa-89e2d3001238" />

To reproduce: 
- Create a new map with 3 Zs
- View Z 2
- Resize from 3 Zs to 2 Zs

Maybe it would address https://github.com/SpaiR/StrongDMM/issues/386 and or https://github.com/SpaiR/StrongDMM/issues/314 but I'm not able to reproduce them as described so I don't know.

# Type of change

<!-- Please check options that are relevant. -->

- [ ] Minor changes or tweaks (quality of life stuff)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
