### PR TITLE
VScodium go to definition

### DIFF
--- a/internal/app/config_preference.go
+++ b/internal/app/config_preference.go
@@ -91,7 +91,10 @@ func (a *app) validateCodeEditor(cfg *preferencesConfig) {
 	switch cfg.Prefs.Editor.CodeEditor {
 	case prefs.CodeEditorVSC:
 		if _, err := exec.LookPath(prefs.CodeEditorVSCActual); err != nil {
-			if _, err := exec.LookPath(prefs.CodeEditorDMActual); err == nil {
+			if _, err := exec.LookPath(prefs.CodeEditorVSCodiumActual); err == nil {
+				// VSC invalid but VSCodium valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorVSCodium
+			} else if _, err := exec.LookPath(prefs.CodeEditorDMActual); err == nil {
 				// VSC invalid but DM valid
 				cfg.Editor.CodeEditor = prefs.CodeEditorDM
 			} else if _, err := exec.LookPath(prefs.CodeEditorNPPActual); err == nil {
@@ -103,11 +106,31 @@ func (a *app) validateCodeEditor(cfg *preferencesConfig) {
 			}
 			log.Print(prefs.CodeEditorVSCActual + " could not be found in PATH. Code Editor pref changed to " + cfg.Editor.CodeEditor)
 		}
+	case prefs.CodeEditorVSCodium:
+		if _, err := exec.LookPath(prefs.CodeEditorVSCodiumActual); err != nil {
+			if _, err := exec.LookPath(prefs.CodeEditorVSCActual); err == nil {
+				// VSCodium invalid but VSC valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorVSC
+			} else if _, err := exec.LookPath(prefs.CodeEditorDMActual); err == nil {
+				// VSCodium invalid but DM valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorDM
+			} else if _, err := exec.LookPath(prefs.CodeEditorNPPActual); err == nil {
+				// VSCodium invalid but NPP valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorNPP
+			} else {
+				// All invalid just default
+				cfg.Editor.CodeEditor = prefs.CodeEditorDefault
+			}
+			log.Print(prefs.CodeEditorVSCodiumActual + " could not be found in PATH. Code Editor pref changed to " + cfg.Editor.CodeEditor)
+		}
 	case prefs.CodeEditorDM:
 		if _, err := exec.LookPath(prefs.CodeEditorDMActual); err != nil {
 			if _, err := exec.LookPath(prefs.CodeEditorVSCActual); err == nil {
 				// DM invalid but VSC valid
 				cfg.Editor.CodeEditor = prefs.CodeEditorVSC
+			} else if _, err := exec.LookPath(prefs.CodeEditorVSCodiumActual); err == nil {
+				// DM invalid but VSCodium valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorVSCodium
 			} else if _, err := exec.LookPath(prefs.CodeEditorNPPActual); err == nil {
 				// DM invalid but NPP valid
 				cfg.Editor.CodeEditor = prefs.CodeEditorNPP
@@ -122,6 +145,9 @@ func (a *app) validateCodeEditor(cfg *preferencesConfig) {
 			if _, err := exec.LookPath(prefs.CodeEditorVSCActual); err == nil {
 				// NPP invalid but VSC valid
 				cfg.Editor.CodeEditor = prefs.CodeEditorVSC
+			} else if _, err := exec.LookPath(prefs.CodeEditorVSCodiumActual); err == nil {
+				// NPP invalid but VSCodium valid
+				cfg.Editor.CodeEditor = prefs.CodeEditorVSCodium
 			} else if _, err := exec.LookPath(prefs.CodeEditorDMActual); err == nil {
 				// NPP invalid but DM valid
 				cfg.Editor.CodeEditor = prefs.CodeEditorDM

--- a/internal/app/prefs/save.go
+++ b/internal/app/prefs/save.go
@@ -18,14 +18,16 @@ var SaveFormats = []string{
 }
 
 const (
-	CodeEditorVSC     = "Visual Studio Code"
-	CodeEditorDM      = "Dreammaker"
-	CodeEditorNPP     = "Notepad++"
-	CodeEditorDefault = "Default App"
+	CodeEditorVSC      = "Visual Studio Code"
+	CodeEditorVSCodium = "VSCodium"
+	CodeEditorDM       = "Dreammaker"
+	CodeEditorNPP      = "Notepad++"
+	CodeEditorDefault  = "Default App"
 
-	CodeEditorVSCActual = "code"
-	CodeEditorDMActual  = "dreammaker"
-	CodeEditorNPPActual = "notepad++"
+	CodeEditorVSCActual      = "code"
+	CodeEditorVSCodiumActual = "codium"
+	CodeEditorDMActual       = "dreammaker"
+	CodeEditorNPPActual      = "notepad++"
 
 	CodeEditorHelp = `These programs must be present in your system PATH to work when using Go to Definition on a prefab.
 Default App and currently Dreammaker can only open to the relevant file, not the specific line number.`
@@ -33,6 +35,7 @@ Default App and currently Dreammaker can only open to the relevant file, not the
 
 var CodeEditors = []string{
 	CodeEditorVSC,
+	CodeEditorVSCodium,
 	CodeEditorDM,
 	CodeEditorNPP,
 	CodeEditorDefault,

--- a/internal/app/ui/cpenvironment/menu.go
+++ b/internal/app/ui/cpenvironment/menu.go
@@ -63,6 +63,10 @@ func (e *Environment) doGoToDefinition(n *treeNode) func() {
 			root := filepath.FromSlash(e.app.LoadedEnvironment().RootDir)
 			argument := path + ":" + fmt.Sprint(location.Line) + ":" + fmt.Sprint(location.Column)
 			command = exec.Command(prefs.CodeEditorVSCActual, root, "-g", argument)
+		case prefs.CodeEditorVSCodium:
+			root := filepath.FromSlash(e.app.LoadedEnvironment().RootDir)
+			argument := path + ":" + fmt.Sprint(location.Line) + ":" + fmt.Sprint(location.Column)
+			command = exec.Command(prefs.CodeEditorVSCodiumActual, root, "-g", argument)
 		case prefs.CodeEditorDM:
 			// No line/col support until https://www.byond.com/forum/post/2970625
 			command = exec.Command(prefs.CodeEditorDMActual, path)


### PR DESCRIPTION
# Description
This PR is a follow up to #348 simply adding vscodium as an option

<img width="1825" height="1050" alt="codium" src="https://github.com/user-attachments/assets/44a20720-9364-46ea-a2e9-959d3ae408ff" />

I wish it didn't have the cmd prompt on windows but same thing I mentioned here is done for codium https://github.com/SpaiR/StrongDMM/pull/348#issuecomment-2849624172

The fallback logic probably ought to be restructured at some point to be an ordered list so it can just inherently handle if the current option is not found, check all other options in order but not exactly certain how to set that up in GO right now.

# Type of change

<!-- Please check options that are relevant. -->

- [X] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
